### PR TITLE
Hardcoding rotp version

### DIFF
--- a/two_factor_authentication.gemspec
+++ b/two_factor_authentication.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rails', '>= 3.1.1'
   s.add_runtime_dependency 'devise'
   s.add_runtime_dependency 'randexp'
-  s.add_runtime_dependency 'rotp', '>= 3.2.0'
+  s.add_runtime_dependency 'rotp', '3.3.0'
   s.add_runtime_dependency 'encryptor'
 
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
This PR (https://github.com/Offerzen/zadev/pull/5318/files) bumped the rotp version up too much too quickly for production... This is a new fork of two_factor_authentication so we can hardcode what we had until we know we can upgrade safely