### PR TITLE
Feature/ignore 2fa for jwt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ rails = case rails_version
         when "master"
           {github: "rails/rails"}
         when "default"
-          "~> 4.1"
+          '~> 6.1'
         else
           "~> #{rails_version}"
         end
@@ -22,6 +22,7 @@ end
 
 group :test, :development do
   gem 'sqlite3'
+  gem 'pry'
 end
 
 group :test do

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -74,6 +74,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   end
 
   def prepare_and_validate
+
     redirect_to :root and return if resource.nil?
     @limit = resource.max_login_attempts
     if resource.max_login_attempts?

--- a/lib/two_factor_authentication/version.rb
+++ b/lib/two_factor_authentication/version.rb
@@ -1,3 +1,3 @@
 module TwoFactorAuthentication
-  VERSION = "2.1.1".freeze
+  VERSION = "2.1.0".freeze
 end

--- a/lib/two_factor_authentication/version.rb
+++ b/lib/two_factor_authentication/version.rb
@@ -1,3 +1,3 @@
 module TwoFactorAuthentication
-  VERSION = "2.0.1".freeze
+  VERSION = "2.1.1".freeze
 end


### PR DESCRIPTION
# Title: Integration of Two-Factor Authentication (2FA) with JWT Authentication

# Description:

This pull request enhances our existing authentication system by integrating two-factor authentication (2FA) with JWT-based authentication. The pull request builds on our previous work with JWT authentication and the existing two-factor authentication that is already present for session-based authentication.

The major changes in this pull request revolve around the Warden::Manager middleware, which is pivotal in our authentication system. We added logic to the existing after_authentication and before_logout callbacks to incorporate JWT handling with 2FA.

# Key Changes:

- **JWT Two-Factor Authentication**: After a successful authentication, if the path is '/api/auth/sign_in' or if the request contains an authorization header (indicating JWT-based authentication), the callback skips the 2FA related code. This is due to the fact that JWTs are only generated after a successful 2FA validation.

- **Existing Session-based Authentication with 2FA**: The existing behavior for session-based authentication is retained. If the user has 2FA enabled and it is a session-based authentication, the system checks if a 2FA cookie is set. If it is not, a new OTP is triggered. This was part of the existing system and has not been altered in this pull request.

- **2FA Cookie Management on Logout**: This behavior was already present and continues to work as before. On user logout, if the configuration delete_cookie_on_logout is enabled, the 2FA cookie is deleted.

In this pull request, we have mainly introduced the functionality to support two-factor authentication with JWT authentication. This goes hand in hand with the existing session-based authentication that was already designed to work with 2FA. The focus was to ensure that JWTs are only generated after a successful 2FA validation.

Reviewers can utilize the instructions from the previous pull request to sign in and sign out with JWTs. Additionally, it would be beneficial to test the session-based authentication flow for users who have 2FA enabled to ensure existing functionality has not been disturbed.

Looking forward to your reviews and feedback. Please reach out if there are any questions or if any aspect requires further clarification or modification.